### PR TITLE
feat: add injection for ruby debugger command strings

### DIFF
--- a/queries/ruby/injections.scm
+++ b/queries/ruby/injections.scm
@@ -9,3 +9,15 @@
 (regex
   (string_content) @injection.content
   (#set! injection.language "regex"))
+
+((call
+  receiver: (identifier) @_receiver
+  method: (identifier) @_method
+  arguments: (argument_list
+    (pair
+      key: (hash_key_symbol)
+      value: (string
+        (string_content) @injection.content))))
+  (#eq? @_receiver "binding")
+  (#any-of? @_method "b" "break")
+  (#set! injection.language "ruby"))

--- a/tests/query/injections/ruby/test-ruby-debugger.rb
+++ b/tests/query/injections/ruby/test-ruby-debugger.rb
@@ -1,0 +1,11 @@
+binding.b(do: "puts 'Hello, world!'")
+#              ^ @ruby
+
+binding.b(pre: "pp [1, 2, 3]")
+#               ^ @ruby
+
+binding.break(do: "puts 'Hello, world!'")
+#                  ^ @ruby
+
+binding.break(pre: "pp [1, 2, 3]")
+#                   ^ @ruby


### PR DESCRIPTION
## What

The [ruby debugger](https://github.com/ruby/debug?tab=readme-ov-file#bindingbreak-method) allows passing a String that gets executed as ruby code before dropping into the debugger.

This PR adds support for marking the string content as ruby code.


```ruby
binding.b(pre: "puts 'run this ruby code before dropping me into the debugger'")
binding.break(do: "puts 'run this ruby code and continue executing'")
```

<img width="302" alt="Screenshot 2024-12-18 at 11 17 26" src="https://github.com/user-attachments/assets/093c5b94-907e-4292-9799-ad8298893fa8" />